### PR TITLE
Fix miui package name for auto_start

### DIFF
--- a/cromappwhitelist/src/main/assets/default_appwhitelist.json
+++ b/cromappwhitelist/src/main/assets/default_appwhitelist.json
@@ -9,7 +9,7 @@
       "cls": "com.meizu.safe.permission.SmartBGActivity"
     },
     {
-      "pkg": "com.huawei.systemmanager",
+      "pkg": "com.miui.securitycenter",
       "cls": "com.miui.permcenter.autostart.AutoStartManagementActivity"
     }
   ],


### PR DESCRIPTION
The pkg is given wrong for Xiaomi in [default_appwhitelist.json](https://github.com/WanghongLin/CRomAppWhitelist/blob/master/cromappwhitelist/src/main/assets/default_appwhitelist.json) file.

Currently:
```
{
      "pkg": "com.huawei.systemmanager",
      "cls": "com.miui.permcenter.autostart.AutoStartManagementActivity"
}
```

Should be:
```
{
      "pkg": "com.miui.securitycenter",
      "cls": "com.miui.permcenter.autostart.AutoStartManagementActivity"
}
```

The pkg name com.miui.securitycenter is based on a Poco x3 device running MIUI 12.0.5 (global version).

Resolves #4